### PR TITLE
feat: add current records index to ctx object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,6 @@
  ],
  */
 
-
 const debug = require('debug')('seeder-foreign-keys');
 const faker = require('faker');
 const get = require('lodash.get');
@@ -90,8 +89,10 @@ module.exports = function (data /* modified in place */, options = {}) {
     debug('process table:', tableName, ourKeyName);
 
     // process each record
-    data[tableName].forEach(rec => {
+    data[tableName].forEach((rec, ix) => {
       debug('.process row', rec);
+
+      ctx.dataCurrIndex = ix;
 
       // no table keys have been shuffled yet for this record
       tableNames.forEach(tableName => {

--- a/tests/expressions.test.js
+++ b/tests/expressions.test.js
@@ -73,6 +73,28 @@ describe('expressions.test.js - handles expressions', () => {
     ]);
   });
 
+  it('reference records index', () => {
+    const recs = {
+      posts: [
+        { _id: 11, name: 'aa', index: '=>ctx.dataCurrIndex' },
+        { _id: 12, name: 'bb', index: '=>ctx.dataCurrIndex' },
+        { _id: 13, name: 'cc', index: '=>ctx.dataCurrIndex' },
+        { _id: 14, name: 'dd', index: '=>ctx.dataCurrIndex' },
+        { _id: 15, name: 'ee', index: '=>ctx.dataCurrIndex' }
+      ]
+    };
+
+    seederFk(recs);
+
+    assert.deepEqual(recs.posts, [
+      { _id: 11, name: 'aa', index: 0 },
+      { _id: 12, name: 'bb', index: 1 },
+      { _id: 13, name: 'cc', index: 2 },
+      { _id: 14, name: 'dd', index: 3 },
+      { _id: 15, name: 'ee', index: 4 }
+    ]);
+  });
+
   it('hashPassword', function () {
     this.timeout(10000);
 


### PR DESCRIPTION
Closes https://github.com/feathers-plus/generator-feathers-plus/issues/254

`ctx` object now contains a property `dataCurrIndex` which holds the array index of the current record being created.

Test has been added.
