### PR TITLE
Where Argument and Expressions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,6 +50,7 @@ const random = require('lodash.random');
 const shuffle = require('lodash.shuffle');
 const traverse = require('traverse');
 const { inspect } = require('util');
+const _ = require('lodash');
 
 const hashPassword = require('../lib/feathersjs/hash-password');
 
@@ -65,17 +66,7 @@ module.exports = function (data /* modified in place */, options = {}) {
   const tablesInfo = {};
 
   tableNames.forEach(tableName => {
-    const table = data[tableName];
-    const sampleRec = table[0];
-    const keyName = !sampleRec ? '_id' : ('id' in sampleRec ? 'id' : '_id');
-
-    tablesInfo[tableName] = {
-      keyName,
-      currRec: -1,
-      isShuffled: false,
-      len: table.length,
-      keys: table.map((record, i) => i)
-    };
+    prepareTableInfo(tableName);
   });
 
   debug('tablesInfo:', tablesInfo);
@@ -169,8 +160,7 @@ module.exports = function (data /* modified in place */, options = {}) {
                     
           if(!tablesInfo[newTableName])
           {
-            data[newTableName] = data[targetTableName];
-            tablesInfo[newTableName] = createReducedTable(whereName, value, targetTableName);
+            createReducedTable(whereName, value, targetTableName, newTableName);
           }
 
           targetTableName = newTableName;
@@ -234,42 +224,41 @@ module.exports = function (data /* modified in place */, options = {}) {
       }
 
       //given a name to match on, create a tableInfo with only keys of records that match 
-      function createReducedTable(name, value, targetTableName)
+      function createReducedTable(name, value, oldTableName, newTableName)
       {        
         
-        
-        const table = data[targetTableName];
-        const sampleRec = table[0];
+		const oldTable = data[oldTableName];
+		
+		const sampleRec = oldTable[0];
 
         if(typeof sampleRec[name] === 'string'
           && (sampleRec[name].indexOf(fkLeader) > -1 || sampleRec[name].indexOf(expLeader) > -1) 
         ) {
 
           //the table we are referring to needs to be processed first
-          processTable(targetTableName);
+          processTable(oldTableName);
         }
 
-        const keyName = !sampleRec ? '_id' : ('id' in sampleRec ? 'id' : '_id');
+		const table = data[newTableName] = _.filter(oldTable, [name, value]);
 
-        let keys = [];
-
-
-        table.forEach((row, i) => {
-          if(row[name] == value)
-          {
-            keys.push(i);
-          }
-        });
-        
-        return {
-          keyName,
-          currRec: -1,
-          isShuffled: false,
-          len: keys.length,
-          keys: keys
-        };
+		prepareTableInfo(newTableName);
       }      
     }   
+  }
+
+  function prepareTableInfo(tableName)
+  {
+	const table = data[tableName];
+    const sampleRec = table[0];
+    const keyName = !sampleRec ? '_id' : ('id' in sampleRec ? 'id' : '_id');
+
+    tablesInfo[tableName] = {
+      keyName,
+      currRec: -1,
+      isShuffled: false,
+      len: table.length,
+      keys: table.map((record, i) => i)
+    };
   }
 
   //assure expressions are ran after all fakers

--- a/lib/index.js
+++ b/lib/index.js
@@ -91,8 +91,11 @@ module.exports = function (data /* modified in place */, options = {}) {
     const ourKeyName = tablesInfo[tableName].keyName;
     debug('process table:', tableName, ourKeyName);
 
-    // process each record
-    data[tableName].forEach((rec, ix) => processRecord(rec, ix));
+    //sort the records to make sure expressions are ran last and  process each record
+    data[tableName].forEach((rec, ix) => {
+      data[tableName][ix] = sortRecord(rec);
+      processRecord(data[tableName][ix], ix);
+    });
       
   }
 
@@ -253,10 +256,42 @@ module.exports = function (data /* modified in place */, options = {}) {
           len: keys.length,
           keys: keys
         };
-      }
-    }
-    
+      }      
+    }   
   }
+
+  //assure expressions are ran after all fakers
+  function sortRecord(rec)
+  {
+    let keys = [], fk = [], exp = [];
+    let obj = {};
+
+    //fk first
+    for(var i in rec) {
+      let r = rec[i];
+      if(isFk(r)) fk.push(i);
+      else if(isExp(r)) exp.push(i);
+      else keys.push(i);
+    }
+
+    keys.concat(fk, exp).forEach(key => {
+      obj[key] = rec[key];
+    })
+
+    return obj;
+  }
+
+  function isFk(value)
+  {
+    return (Array.isArray(value) && isFk(value[0]) || (typeof value === 'string' && value.substr(0, fkLeaderLen) === fkLeader));
+  }
+
+  function isExp(value)
+  {
+    return (Array.isArray(value) && isExp(value[0]) || (typeof value === 'string' && value.substr(0, expLeaderLen) === expLeader));
+  }
+
+
 };
 
 function bumpCurrRec (targetTableInfo /* modified */) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -261,8 +261,6 @@ module.exports = function (data /* modified in place */, options = {}) {
           }
         });
         
-        console.log(targetTableName, keys);
-
         return {
           keyName,
           currRec: -1,

--- a/lib/index.js
+++ b/lib/index.js
@@ -161,7 +161,7 @@ module.exports = function (data /* modified in place */, options = {}) {
         fieldName = fieldName || keyName;
         debug('...target', keyName, isShuffled, len, keys);
 
-        if (len === 0) throw new Error(`${value}: table has no records. (seeder-foreign-keys)`);
+        if (len === 0) throw new Error(`${targetTableName}: table has no records. (seeder-foreign-keys)`);
 
         // Get index of target record
         let index;
@@ -222,7 +222,10 @@ module.exports = function (data /* modified in place */, options = {}) {
           replacePlaceholders.call({
             key: name,
             isLeaf: true,
-            update: (newValue) => { rec[name] = newValue }
+            update: (newValue) => { 
+              rec[name] = newValue; 
+              value = newValue; 
+            }
           }, value);
         }
         

--- a/lib/index.js
+++ b/lib/index.js
@@ -84,107 +84,179 @@ module.exports = function (data /* modified in place */, options = {}) {
   const ctx = Object.assign({}, { data, faker, tablesInfo, hashPassword }, options.expContext || {});
 
   // process each table
-  tableNames.forEach(tableName => {
+  tableNames.forEach(tableName => processTable(tableName));
+
+  function processTable(tableName)
+  {
     const ourKeyName = tablesInfo[tableName].keyName;
     debug('process table:', tableName, ourKeyName);
 
     // process each record
-    data[tableName].forEach((rec, ix) => {
-      debug('.process row', rec);
+    data[tableName].forEach((rec, ix) => processRecord(rec, ix));
+      
+  }
 
-      ctx.dataCurrIndex = ix;
 
-      // no table keys have been shuffled yet for this record
-      tableNames.forEach(tableName => {
-        const tableInfo = tablesInfo[tableName];
-        tableInfo.isShuffled = false;
-        if (!testModeIndex) tableInfo.currRec = -1;
-      });
+  function processRecord(rec, ix)
+  {
+    debug('.process row', rec);
 
-      // debug('..prep tablesInfo', tablesInfo)
+    ctx.dataCurrIndex = ix;
+
+    // no table keys have been shuffled yet for this record
+    tableNames.forEach(tableName => {
+      const tableInfo = tablesInfo[tableName];
+      tableInfo.isShuffled = false;
+      if (!testModeIndex) tableInfo.currRec = -1;
+    });
+
+    // debug('..prep tablesInfo', tablesInfo)
 
       // traverse the row's properties
       traverse(rec).forEach(replacePlaceholders); // `rec` is converted in place.
 
-      function replacePlaceholders (value) {
-        if (!this.isLeaf) return;
+    function replacePlaceholders (value) {
+      if (!this.isLeaf) return;
 
-        // handle foreign keys
-        if (typeof value === 'string' && value.substr(0, fkLeaderLen) === fkLeader) {
-          replaceForeignKey(this);
-        }
+      // handle foreign keys
+      if (typeof value === 'string' && value.substr(0, fkLeaderLen) === fkLeader) {
+        replaceForeignKey(this);
+      }
 
-        // handle expressions
-        if (typeof value === 'string' && value.substr(0, expLeaderLen) === expLeader) {
-          replaceExpression(this);
-        }
+      // handle expressions
+      if (typeof value === 'string' && value.substr(0, expLeaderLen) === expLeader) {
+        replaceExpression(this);
+      }
 
-        function replaceForeignKey (that) {
-          debug('...fk leaf:', that.key, value);
+      function replaceForeignKey (that) {
+        debug('...fk leaf:', that.key, value);
 
-          // Validate placeholder
-          const ph = value.substr(fkLeaderLen);
-          let [targetTableName = '', randomType = 'random', fieldName] = ph.split(':');
+        // Validate placeholder
+        const ph = value.substr(fkLeaderLen);
+        let [targetTableName = '', randomType = 'random', fieldName, whereName] = ph.split(':');
 
-          const targetTableInfo = tablesInfo[targetTableName];
-          debug('...ph', targetTableName, randomType, fieldName, targetTableInfo);
-          if (!targetTableInfo) throw new Error(`${value}: table not found. (seeder-foreign-keys)`);
-
-          // Get target table information
-          let { keyName, isShuffled, len, keys } = targetTableInfo;
-          fieldName = fieldName || keyName;
-          debug('...target', keyName, isShuffled, len, keys);
-
-          if (len === 0) throw new Error(`${value}: table has no records. (seeder-foreign-keys)`);
-
-          // Get index of target record
-          let index;
-          switch (randomType) {
-            case 'random':
-              index = testModeIndex ? bumpCurrRec(targetTableInfo) : random(len - 1);
-              break;
-            case 'next':
-              debug('...next', isShuffled, testModeIndex);
-              if (!isShuffled && !testModeIndex) {
-                keys = targetTableInfo.keys = shuffle(keys);
-                targetTableInfo.currRec = -1;
-              }
-
-              targetTableInfo.isShuffled = true;
-              index = keys[bumpCurrRec(targetTableInfo)];
-              break;
-            case 'curr':
-              if (!isShuffled) throw new Error(`${value}: no prior "next". (seeder-foreign-keys)`);
-
-              index = tablesInfo[targetTableName].currRec;
-              break;
-            default:
-              throw new Error(`${value}: invalid random type. (seeder-foreign-keys)`);
+        //create a reduced table using where name
+        if(whereName)
+        {
+          let newTableName = targetTableName + '_' + whereName;
+          
+          if(!tablesInfo[newTableName])
+          {
+            data[newTableName] = data[targetTableName];
+            tablesInfo[newTableName] = createReducedTable(whereName, targetTableName);
           }
-          debug('...index', index, len, testModeIndex);
 
-          // Replace by target field value
-          const targetValue = get(data[targetTableName][index], fieldName);
-          that.update(targetValue);
+          targetTableName = newTableName;
         }
 
-        function replaceExpression (that) {
-          debug('...exp leaf:', that.key, value);
-          const exp = value.substr(expLeaderLen);
+        const targetTableInfo = tablesInfo[targetTableName];
+        debug('...ph', targetTableName, randomType, fieldName, targetTableInfo);
+        if (!targetTableInfo) throw new Error(`${value}: table not found. (seeder-foreign-keys)`);
 
-          try {
-            const func = new Function('rec', 'ctx', `return ${exp};`);
-            const val = func(rec, ctx, data);
-            debug('val', val);
-            that.update(val);
-          } catch (err) {
-            console.log(err);
-            throw new Error(`${value}: ${err.message}. (seeder-foreign-keys)`);
-          }
+        // Get target table information
+        let { keyName, isShuffled, len, keys } = targetTableInfo;
+        fieldName = fieldName || keyName;
+        debug('...target', keyName, isShuffled, len, keys);
+
+        if (len === 0) throw new Error(`${value}: table has no records. (seeder-foreign-keys)`);
+
+        // Get index of target record
+        let index;
+        switch (randomType) {
+          case 'random':
+            index = testModeIndex ? bumpCurrRec(targetTableInfo) : random(len - 1);
+            break;
+          case 'next':
+            debug('...next', isShuffled, testModeIndex);
+            if (!isShuffled && !testModeIndex) {
+              keys = targetTableInfo.keys = shuffle(keys);
+              targetTableInfo.currRec = -1;
+            }
+
+            targetTableInfo.isShuffled = true;
+            index = keys[bumpCurrRec(targetTableInfo)];
+            break;
+          case 'curr':
+            if (!isShuffled) throw new Error(`${value}: no prior "next". (seeder-foreign-keys)`);
+
+            index = tablesInfo[targetTableName].currRec;
+            break;
+          default:
+            throw new Error(`${value}: invalid random type. (seeder-foreign-keys)`);
+        }
+        debug('...index', index, len, testModeIndex);
+
+        // Replace by target field value
+        const targetValue = get(data[targetTableName][index], fieldName);
+        that.update(targetValue);
+      }
+
+      function replaceExpression (that) {
+        debug('...exp leaf:', that.key, value);
+        const exp = value.substr(expLeaderLen);
+
+        try {
+          const func = new Function('rec', 'ctx', `return ${exp};`);
+          const val = func(rec, ctx, data);
+          debug('val', val);
+          that.update(val);
+        } catch (err) {
+          console.log(err);
+          throw new Error(`${value}: ${err.message}. (seeder-foreign-keys)`);
         }
       }
-    });
-  });
+
+      //given a name to match on, create a tableInfo with only keys of records that match 
+      function createReducedTable(name, targetTableName)
+      {        
+        let value = rec[name];
+        if(!value) throw new Error(`${name}: must exist in record schema. (seeder-foreign-keys)`);
+        
+        //field is also a faker, need to replace the referenced node first
+        if(typeof value === 'string'
+          && (value.indexOf(fkLeader) > -1 || value.indexOf(expLeader) > -1) 
+        ) {
+          replacePlaceholders.call({
+            key: name,
+            isLeaf: true,
+            update: (newValue) => { rec[name] = newValue }
+          }, whereValue);
+        }
+        
+        const table = data[targetTableName];
+        const sampleRec = table[0];
+
+        if(typeof sampleRec[name] === 'string'
+          && (sampleRec[name].indexOf(fkLeader) > -1 || sampleRec[name].indexOf(expLeader) > -1) 
+        ) {
+
+          //the table we are referring to needs to be processed first
+          processTable(targetTableName);
+        }
+
+        const keyName = !sampleRec ? '_id' : ('id' in sampleRec ? 'id' : '_id');
+
+        let keys = [];
+
+
+        table.forEach((row, i) => {
+          if(row[name] == value)
+          {
+            keys.push(i);
+          }
+        });
+
+        return {
+          keyName,
+          currRec: -1,
+          isShuffled: false,
+          len: keys.length,
+          keys: keys
+        };
+      }
+    }
+    
+  }
 };
 
 function bumpCurrRec (targetTableInfo /* modified */) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -137,16 +137,40 @@ module.exports = function (data /* modified in place */, options = {}) {
         // Validate placeholder
         const ph = value.substr(fkLeaderLen);
         let [targetTableName = '', randomType = 'random', fieldName, whereName] = ph.split(':');
+        
+        
 
         //create a reduced table using where name
+        
+        
         if(whereName)
         {
-          let newTableName = targetTableName + '_' + whereName;
           
+          //get value to match on
+          let value = rec[whereName];
+          
+          if(!value) throw new Error(`${name}: must exist in record schema. (seeder-foreign-keys)`);
+          
+          //field is also a faker, need to replace the referenced node first
+          if(typeof value === 'string'
+            && (value.indexOf(fkLeader) > -1 || value.indexOf(expLeader) > -1) 
+          ) {
+            replacePlaceholders.call({
+              key: whereName,
+              isLeaf: true,
+              update: (newValue) => { 
+                rec[whereName] = newValue; 
+                value = newValue; 
+              }
+            }, value);
+          }	
+		
+          let newTableName = targetTableName + '_' + whereName + '_' + value;
+                    
           if(!tablesInfo[newTableName])
           {
             data[newTableName] = data[targetTableName];
-            tablesInfo[newTableName] = createReducedTable(whereName, targetTableName);
+            tablesInfo[newTableName] = createReducedTable(whereName, value, targetTableName);
           }
 
           targetTableName = newTableName;
@@ -210,24 +234,9 @@ module.exports = function (data /* modified in place */, options = {}) {
       }
 
       //given a name to match on, create a tableInfo with only keys of records that match 
-      function createReducedTable(name, targetTableName)
+      function createReducedTable(name, value, targetTableName)
       {        
-        let value = rec[name];
-        if(!value) throw new Error(`${name}: must exist in record schema. (seeder-foreign-keys)`);
         
-        //field is also a faker, need to replace the referenced node first
-        if(typeof value === 'string'
-          && (value.indexOf(fkLeader) > -1 || value.indexOf(expLeader) > -1) 
-        ) {
-          replacePlaceholders.call({
-            key: name,
-            isLeaf: true,
-            update: (newValue) => { 
-              rec[name] = newValue; 
-              value = newValue; 
-            }
-          }, value);
-        }
         
         const table = data[targetTableName];
         const sampleRec = table[0];
@@ -251,6 +260,8 @@ module.exports = function (data /* modified in place */, options = {}) {
             keys.push(i);
           }
         });
+        
+        console.log(targetTableName, keys);
 
         return {
           keyName,

--- a/lib/index.js
+++ b/lib/index.js
@@ -223,7 +223,7 @@ module.exports = function (data /* modified in place */, options = {}) {
             key: name,
             isLeaf: true,
             update: (newValue) => { rec[name] = newValue }
-          }, whereValue);
+          }, value);
         }
         
         const table = data[targetTableName];


### PR DESCRIPTION
- Added a fourth argument to fk syntax for a where statement. For example, allows you to match other records that have a common key such as user id where only random records that belong to that user are desired.

- Added functionality to make sure expressions run last. Ensures that fk data can be used in expressions. For example, a record has faked foreign keys for images, and you want to use an expression to select one of those records as the defaultImage field. 